### PR TITLE
fix: themeAction should use an absolute path when calling from a nested route

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ export const loader: LoaderFunction = async ({request}) => {
 export default function AppWithProviders() {
   const data = useLoaderData()
   return (
-    <ThemeProvider specifiedTheme={data.theme} themeAction="action/set-theme">
+    <ThemeProvider specifiedTheme={data.theme} themeAction="/action/set-theme">
       <App />
     </ThemeProvider>
   )
@@ -104,7 +104,8 @@ Create a file in `/routes/action/set-theme.ts` with the content below. Ensure
 that you pass the filename to the `ThemeProvider` component.
 
 > Note: You can name the action route whatever you want. Just make sure you pass
-> the correct action name to the `ThemeProvider` component.
+> the correct action name to the `ThemeProvider` component. Make sure to use absolute
+> path when using nested routing.
 
 This route it's used to store the preferred theme in the session storage when
 the user changes it.

--- a/demo/app/root.tsx
+++ b/demo/app/root.tsx
@@ -74,7 +74,7 @@ function App() {
 export default function AppWithProviders() {
   const data = useLoaderData()
   return (
-    <ThemeProvider specifiedTheme={data.theme} themeAction="action/set-theme">
+    <ThemeProvider specifiedTheme={data.theme} themeAction="/action/set-theme">
       <App />
     </ThemeProvider>
   )


### PR DESCRIPTION
My `<button>` to control setTheme lives in a nested route. The relative path in the documentation and example app caused a few errors that took a bit to figure out. This should make it easier.