### PR TITLE
feat: add `selectionMode` on ThemeProvider

### DIFF
--- a/packages/remix-themes/src/theme-provider.test.tsx
+++ b/packages/remix-themes/src/theme-provider.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {vi} from 'vitest'
 import {waitFor, render} from '@testing-library/react'
 import {act, renderHook} from '@testing-library/react-hooks'
-import type {ThemeProviderProps} from './theme-provider'
+import {SelectionMode, ThemeProviderProps} from './theme-provider'
 import {
   ThemeProvider,
   useTheme,
@@ -91,7 +91,7 @@ describe('theme-provider', () => {
     expect(result.current[0]).toBe(preferredTheme)
   })
 
-  it('updates automatically when the system theme  changes', async () => {
+  it('updates automatically when the system theme changes', async () => {
     const prefersLightMQ = '(prefers-color-scheme: light)'
 
     const {result} = renderHook(() => useTheme(), {
@@ -111,6 +111,47 @@ describe('theme-provider', () => {
 
     await waitFor(() => {
       expect(result.current[0]).toBe(Theme.DARK)
+    })
+
+    act(() => {
+      mediaQuery?.dispatchEvent(
+        new MediaQueryListEvent('change', {
+          media: prefersLightMQ,
+          matches: true,
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(Theme.LIGHT)
+    })
+  })
+
+  it('ignores system theme when selection mode is "user"', async () => {
+    const prefersLightMQ = '(prefers-color-scheme: light)'
+
+    const {result} = renderHook(() => useTheme(), {
+      wrapper: (props: ThemeProviderProps) => (
+        <ThemeProvider
+          {...props}
+          themeAction={themeAction}
+          specifiedTheme={Theme.LIGHT}
+          selectionMode={SelectionMode.USER}
+        />
+      ),
+    })
+
+    act(() => {
+      mediaQuery?.dispatchEvent(
+        new MediaQueryListEvent('change', {
+          media: prefersLightMQ,
+          matches: false,
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(Theme.LIGHT)
     })
 
     act(() => {

--- a/packages/remix-themes/src/theme-provider.tsx
+++ b/packages/remix-themes/src/theme-provider.tsx
@@ -17,6 +17,11 @@ ThemeContext.displayName = 'ThemeContext'
 
 const prefersLightMQ = '(prefers-color-scheme: light)'
 
+export enum SelectionMode {
+  USER = 'user',
+  SYSTEM = 'system',
+}
+
 const getPreferredTheme = () =>
   window.matchMedia(prefersLightMQ).matches ? Theme.LIGHT : Theme.DARK
 
@@ -28,6 +33,7 @@ export type ThemeProviderProps = {
   specifiedTheme: Theme | null
   themeAction: string
   disableTransitionOnThemeChange?: boolean
+  selectionMode?: SelectionMode
 }
 
 export function ThemeProvider({
@@ -35,6 +41,7 @@ export function ThemeProvider({
   specifiedTheme,
   themeAction,
   disableTransitionOnThemeChange = false,
+  selectionMode = SelectionMode.SYSTEM,
 }: ThemeProviderProps) {
   const ensureCorrectTransition = useCorrectCssTransition({
     disableTransitions: disableTransitionOnThemeChange,
@@ -82,6 +89,10 @@ export function ThemeProvider({
   }, [broadcastThemeChange, theme, themeAction, ensureCorrectTransition])
 
   useEffect(() => {
+    if (selectionMode !== SelectionMode.SYSTEM) {
+      return
+    }
+
     const handleChange = (ev: MediaQueryListEvent) => {
       ensureCorrectTransition(() => {
         setTheme(ev.matches ? Theme.LIGHT : Theme.DARK)
@@ -89,7 +100,7 @@ export function ThemeProvider({
     }
     mediaQuery?.addEventListener('change', handleChange)
     return () => mediaQuery?.removeEventListener('change', handleChange)
-  }, [ensureCorrectTransition])
+  }, [ensureCorrectTransition, selectionMode])
 
   return (
     <ThemeContext.Provider value={[theme, setTheme]}>


### PR DESCRIPTION
The new prop accepts 2 options:

* SYSTEM (default): update the theme based on media color-scheme
* USER: disable updating the theme based color-scheme and uses the provided theme

closes: #32 #33