### PR TITLE
feat(theme-provider): Suppress hydration warning and add String.raw

### DIFF
--- a/packages/remix-themes/src/theme-provider.tsx
+++ b/packages/remix-themes/src/theme-provider.tsx
@@ -140,7 +140,7 @@ export function ThemeProvider({
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }
 
-const clientThemeCode = `
+const clientThemeCode = String.raw`
 (() => {
   const theme = window.matchMedia(${JSON.stringify(prefersLightMQ)}).matches
     ? 'light'
@@ -205,6 +205,7 @@ export function PreventFlashOnWrongTheme({
           // is finished loading.
           dangerouslySetInnerHTML={{__html: clientThemeCode}}
           nonce={nonce}
+          suppressHydrationWarning
         />
       )}
     </>


### PR DESCRIPTION
This commit suppresses the hydration warning in the browser by adding `suppressHydrationWarning` to the script tag. This is necessary to prevent the browser from throwing a warning about extra attributes from the server, specifically `nonce`.

Additionally, `String.raw` has been added for the manually injected script content. This is used to get the raw string form of template strings, which is useful when you want to avoid processing of escape sequences.